### PR TITLE
Add comprehensive test coverage for JWT and JWK packages

### DIFF
--- a/pkg/json/jose/jwk/types/key/ec/ec_test.go
+++ b/pkg/json/jose/jwk/types/key/ec/ec_test.go
@@ -1,0 +1,323 @@
+package ec
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"encoding/base64"
+	"errors"
+	"math/big"
+	"testing"
+
+	motmedelJwkErrors "github.com/Motmedel/utils_go/pkg/json/jose/jwk/errors"
+)
+
+func TestCurveFromCrv(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		crv      string
+		expected elliptic.Curve
+	}{
+		{
+			name:     "P-256",
+			crv:      "P-256",
+			expected: elliptic.P256(),
+		},
+		{
+			name:     "P-384",
+			crv:      "P-384",
+			expected: elliptic.P384(),
+		},
+		{
+			name:     "P-521",
+			crv:      "P-521",
+			expected: elliptic.P521(),
+		},
+		{
+			name:     "unknown curve",
+			crv:      "P-999",
+			expected: nil,
+		},
+		{
+			name:     "empty string",
+			crv:      "",
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := curveFromCrv(tc.crv)
+			if result != tc.expected {
+				t.Fatalf("expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestKey_PublicKey(t *testing.T) {
+	t.Parallel()
+
+	// Generate valid EC coordinates for P-256 (using a known test vector)
+	// These are arbitrary but valid-looking base64 encoded coordinates
+	validX := base64.RawURLEncoding.EncodeToString(make([]byte, 32)) // 32 bytes for P-256
+	validY := base64.RawURLEncoding.EncodeToString(make([]byte, 32))
+
+	testCases := []struct {
+		name        string
+		key         *Key
+		expectError bool
+		errorCheck  func(error) bool
+	}{
+		{
+			name: "valid P-256 key",
+			key: &Key{
+				Crv: "P-256",
+				X:   validX,
+				Y:   validY,
+			},
+			expectError: false,
+		},
+		{
+			name: "valid P-384 key",
+			key: &Key{
+				Crv: "P-384",
+				X:   base64.RawURLEncoding.EncodeToString(make([]byte, 48)),
+				Y:   base64.RawURLEncoding.EncodeToString(make([]byte, 48)),
+			},
+			expectError: false,
+		},
+		{
+			name: "valid P-521 key",
+			key: &Key{
+				Crv: "P-521",
+				X:   base64.RawURLEncoding.EncodeToString(make([]byte, 66)),
+				Y:   base64.RawURLEncoding.EncodeToString(make([]byte, 66)),
+			},
+			expectError: false,
+		},
+		{
+			name: "unsupported curve",
+			key: &Key{
+				Crv: "P-999",
+				X:   validX,
+				Y:   validY,
+			},
+			expectError: true,
+			errorCheck: func(err error) bool {
+				return errors.Is(err, motmedelJwkErrors.ErrUnsupportedCrv)
+			},
+		},
+		{
+			name: "invalid base64 X",
+			key: &Key{
+				Crv: "P-256",
+				X:   "!!!invalid!!!",
+				Y:   validY,
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid base64 Y",
+			key: &Key{
+				Crv: "P-256",
+				X:   validX,
+				Y:   "!!!invalid!!!",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pk, err := tc.key.PublicKey()
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				if tc.errorCheck != nil && !tc.errorCheck(err) {
+					t.Fatalf("error check failed for error: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				_, ok := pk.(*ecdsa.PublicKey)
+				if !ok {
+					t.Fatalf("expected *ecdsa.PublicKey, got %T", pk)
+				}
+			}
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	validX := base64.RawURLEncoding.EncodeToString(big.NewInt(12345).Bytes())
+	validY := base64.RawURLEncoding.EncodeToString(big.NewInt(67890).Bytes())
+
+	testCases := []struct {
+		name        string
+		input       map[string]any
+		expected    *Key
+		expectError bool
+		errorCheck  func(error) bool
+	}{
+		{
+			name:     "nil map",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name: "valid EC key",
+			input: map[string]any{
+				"kty": "EC",
+				"crv": "P-256",
+				"x":   validX,
+				"y":   validY,
+			},
+			expected: &Key{
+				Crv: "P-256",
+				X:   validX,
+				Y:   validY,
+			},
+		},
+		{
+			name: "wrong kty",
+			input: map[string]any{
+				"kty": "RSA",
+				"crv": "P-256",
+				"x":   validX,
+				"y":   validY,
+			},
+			expectError: true,
+			errorCheck: func(err error) bool {
+				return errors.Is(err, motmedelJwkErrors.ErrKtyMismatch)
+			},
+		},
+		{
+			name: "missing kty",
+			input: map[string]any{
+				"crv": "P-256",
+				"x":   validX,
+				"y":   validY,
+			},
+			expectError: true,
+		},
+		{
+			name: "missing crv",
+			input: map[string]any{
+				"kty": "EC",
+				"x":   validX,
+				"y":   validY,
+			},
+			expectError: true,
+		},
+		{
+			name: "missing x",
+			input: map[string]any{
+				"kty": "EC",
+				"crv": "P-256",
+				"y":   validY,
+			},
+			expectError: true,
+		},
+		{
+			name: "missing y",
+			input: map[string]any{
+				"kty": "EC",
+				"crv": "P-256",
+				"x":   validX,
+			},
+			expectError: true,
+		},
+		{
+			name: "kty wrong type",
+			input: map[string]any{
+				"kty": 123,
+				"crv": "P-256",
+				"x":   validX,
+				"y":   validY,
+			},
+			expectError: true,
+		},
+		{
+			name: "crv wrong type",
+			input: map[string]any{
+				"kty": "EC",
+				"crv": 256,
+				"x":   validX,
+				"y":   validY,
+			},
+			expectError: true,
+		},
+		{
+			name: "x wrong type",
+			input: map[string]any{
+				"kty": "EC",
+				"crv": "P-256",
+				"x":   123,
+				"y":   validY,
+			},
+			expectError: true,
+		},
+		{
+			name: "y wrong type",
+			input: map[string]any{
+				"kty": "EC",
+				"crv": "P-256",
+				"x":   validX,
+				"y":   123,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			key, err := New(tc.input)
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				if tc.errorCheck != nil && !tc.errorCheck(err) {
+					t.Fatalf("error check failed for error: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				if tc.expected == nil {
+					if key != nil {
+						t.Fatalf("expected nil, got %v", key)
+					}
+				} else {
+					if key == nil {
+						t.Fatal("expected non-nil key, got nil")
+					}
+					if key.Crv != tc.expected.Crv {
+						t.Fatalf("expected Crv=%s, got Crv=%s", tc.expected.Crv, key.Crv)
+					}
+					if key.X != tc.expected.X {
+						t.Fatalf("expected X=%s, got X=%s", tc.expected.X, key.X)
+					}
+					if key.Y != tc.expected.Y {
+						t.Fatalf("expected Y=%s, got Y=%s", tc.expected.Y, key.Y)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/json/jose/jwk/types/key/rsa/rsa_test.go
+++ b/pkg/json/jose/jwk/types/key/rsa/rsa_test.go
@@ -1,0 +1,230 @@
+package rsa
+
+import (
+	"crypto/rsa"
+	"encoding/base64"
+	"errors"
+	"math/big"
+	"testing"
+
+	motmedelJwkErrors "github.com/Motmedel/utils_go/pkg/json/jose/jwk/errors"
+)
+
+func TestKey_PublicKey(t *testing.T) {
+	t.Parallel()
+
+	// Valid RSA public key components (small example for testing)
+	validN := base64.RawURLEncoding.EncodeToString(big.NewInt(3233).Bytes())   // n = 3233 = 61 * 53
+	validE := base64.RawURLEncoding.EncodeToString(big.NewInt(17).Bytes())     // e = 17
+
+	testCases := []struct {
+		name        string
+		key         *Key
+		expectError bool
+		validate    func(*rsa.PublicKey) bool
+	}{
+		{
+			name: "valid key",
+			key: &Key{
+				N: validN,
+				E: validE,
+			},
+			expectError: false,
+			validate: func(pk *rsa.PublicKey) bool {
+				return pk.N.Cmp(big.NewInt(3233)) == 0 && pk.E == 17
+			},
+		},
+		{
+			name: "invalid base64 N",
+			key: &Key{
+				N: "!!!invalid!!!",
+				E: validE,
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid base64 E",
+			key: &Key{
+				N: validN,
+				E: "!!!invalid!!!",
+			},
+			expectError: true,
+		},
+		{
+			name: "empty N",
+			key: &Key{
+				N: "",
+				E: validE,
+			},
+			expectError: false, // Empty string is valid base64, results in zero
+		},
+		{
+			name: "empty E",
+			key: &Key{
+				N: validN,
+				E: "",
+			},
+			expectError: false, // Empty string is valid base64, results in zero exponent
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pk, err := tc.key.PublicKey()
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				rsaPK, ok := pk.(*rsa.PublicKey)
+				if !ok {
+					t.Fatalf("expected *rsa.PublicKey, got %T", pk)
+				}
+
+				if tc.validate != nil && !tc.validate(rsaPK) {
+					t.Fatalf("validation failed for public key: N=%v, E=%v", rsaPK.N, rsaPK.E)
+				}
+			}
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	validN := base64.RawURLEncoding.EncodeToString(big.NewInt(3233).Bytes())
+	validE := base64.RawURLEncoding.EncodeToString(big.NewInt(17).Bytes())
+
+	testCases := []struct {
+		name        string
+		input       map[string]any
+		expected    *Key
+		expectError bool
+		errorCheck  func(error) bool
+	}{
+		{
+			name:     "nil map",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name: "valid RSA key",
+			input: map[string]any{
+				"kty": "RSA",
+				"n":   validN,
+				"e":   validE,
+			},
+			expected: &Key{
+				N: validN,
+				E: validE,
+			},
+		},
+		{
+			name: "wrong kty",
+			input: map[string]any{
+				"kty": "EC",
+				"n":   validN,
+				"e":   validE,
+			},
+			expectError: true,
+			errorCheck: func(err error) bool {
+				return errors.Is(err, motmedelJwkErrors.ErrKtyMismatch)
+			},
+		},
+		{
+			name: "missing kty",
+			input: map[string]any{
+				"n": validN,
+				"e": validE,
+			},
+			expectError: true,
+		},
+		{
+			name: "missing n",
+			input: map[string]any{
+				"kty": "RSA",
+				"e":   validE,
+			},
+			expectError: true,
+		},
+		{
+			name: "missing e",
+			input: map[string]any{
+				"kty": "RSA",
+				"n":   validN,
+			},
+			expectError: true,
+		},
+		{
+			name: "kty wrong type",
+			input: map[string]any{
+				"kty": 123,
+				"n":   validN,
+				"e":   validE,
+			},
+			expectError: true,
+		},
+		{
+			name: "n wrong type",
+			input: map[string]any{
+				"kty": "RSA",
+				"n":   123,
+				"e":   validE,
+			},
+			expectError: true,
+		},
+		{
+			name: "e wrong type",
+			input: map[string]any{
+				"kty": "RSA",
+				"n":   validN,
+				"e":   123,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			key, err := New(tc.input)
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				if tc.errorCheck != nil && !tc.errorCheck(err) {
+					t.Fatalf("error check failed for error: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				if tc.expected == nil {
+					if key != nil {
+						t.Fatalf("expected nil, got %v", key)
+					}
+				} else {
+					if key == nil {
+						t.Fatal("expected non-nil key, got nil")
+					}
+					if key.N != tc.expected.N {
+						t.Fatalf("expected N=%s, got N=%s", tc.expected.N, key.N)
+					}
+					if key.E != tc.expected.E {
+						t.Fatalf("expected E=%s, got E=%s", tc.expected.E, key.E)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/json/jose/jwt/jwt_test.go
+++ b/pkg/json/jose/jwt/jwt_test.go
@@ -1,0 +1,320 @@
+package jwt
+
+import (
+	"encoding/base64"
+	"errors"
+	"testing"
+	"time"
+
+	motmedelErrors "github.com/Motmedel/utils_go/pkg/errors"
+	jwtErrors "github.com/Motmedel/utils_go/pkg/json/jose/jwt/errors"
+)
+
+func TestSplitToken(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		token       string
+		expected    [3]string
+		expectError bool
+	}{
+		{
+			name:        "empty token",
+			token:       "",
+			expected:    [3]string{},
+			expectError: true,
+		},
+		{
+			name:        "single part",
+			token:       "header",
+			expected:    [3]string{},
+			expectError: true,
+		},
+		{
+			name:        "two parts",
+			token:       "header.payload",
+			expected:    [3]string{},
+			expectError: true,
+		},
+		{
+			name:        "three parts",
+			token:       "header.payload.signature",
+			expected:    [3]string{"header", "payload", "signature"},
+			expectError: false,
+		},
+		{
+			name:        "four parts (extra dots in signature)",
+			token:       "header.payload.sig.nature",
+			expected:    [3]string{"header", "payload", "sig.nature"},
+			expectError: false,
+		},
+		{
+			name:        "empty parts",
+			token:       "..",
+			expected:    [3]string{"", "", ""},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parts, err := SplitToken(tc.token)
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				if !errors.Is(err, motmedelErrors.ErrBadSplit) {
+					t.Fatalf("expected ErrBadSplit, got: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+				if parts != tc.expected {
+					t.Fatalf("expected %v, got %v", tc.expected, parts)
+				}
+			}
+		})
+	}
+}
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	// Create valid base64-encoded parts
+	validHeader := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256"}`))
+	validPayload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"1234567890"}`))
+	validSignature := base64.RawURLEncoding.EncodeToString([]byte("signature"))
+
+	testCases := []struct {
+		name           string
+		token          string
+		expectedHeader []byte
+		expectError    bool
+	}{
+		{
+			name:        "empty token",
+			token:       "",
+			expectError: true,
+		},
+		{
+			name:        "invalid split",
+			token:       "only.two",
+			expectError: true,
+		},
+		{
+			name:        "invalid base64 header",
+			token:       "!!!invalid!!!" + "." + validPayload + "." + validSignature,
+			expectError: true,
+		},
+		{
+			name:        "invalid base64 payload",
+			token:       validHeader + ".!!!invalid!!!." + validSignature,
+			expectError: true,
+		},
+		{
+			name:        "invalid base64 signature",
+			token:       validHeader + "." + validPayload + ".!!!invalid!!!",
+			expectError: true,
+		},
+		{
+			name:           "valid token",
+			token:          validHeader + "." + validPayload + "." + validSignature,
+			expectedHeader: []byte(`{"alg":"HS256"}`),
+			expectError:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			header, _, _, err := Parse(tc.token)
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+				if string(header) != string(tc.expectedHeader) {
+					t.Fatalf("expected header %s, got %s", tc.expectedHeader, header)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateExpiresAt(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	testCases := []struct {
+		name        string
+		expiresAt   time.Time
+		cmp         time.Time
+		expectError error
+	}{
+		{
+			name:        "not expired",
+			expiresAt:   now.Add(time.Hour),
+			cmp:         now,
+			expectError: nil,
+		},
+		{
+			name:        "expired",
+			expiresAt:   now.Add(-time.Hour),
+			cmp:         now,
+			expectError: jwtErrors.ErrExpExpired,
+		},
+		{
+			name:        "exactly at expiration",
+			expiresAt:   now,
+			cmp:         now,
+			expectError: nil,
+		},
+		{
+			name:        "one nanosecond after expiration",
+			expiresAt:   now,
+			cmp:         now.Add(time.Nanosecond),
+			expectError: jwtErrors.ErrExpExpired,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateExpiresAt(tc.expiresAt, tc.cmp)
+
+			if tc.expectError == nil {
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+			} else {
+				if !errors.Is(err, tc.expectError) {
+					t.Fatalf("expected error %v, got: %v", tc.expectError, err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateNotBefore(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	testCases := []struct {
+		name        string
+		notBefore   time.Time
+		cmp         time.Time
+		expectError error
+	}{
+		{
+			name:        "after not before",
+			notBefore:   now.Add(-time.Hour),
+			cmp:         now,
+			expectError: nil,
+		},
+		{
+			name:        "before not before",
+			notBefore:   now.Add(time.Hour),
+			cmp:         now,
+			expectError: jwtErrors.ErrNbfBefore,
+		},
+		{
+			name:        "exactly at not before",
+			notBefore:   now,
+			cmp:         now,
+			expectError: nil,
+		},
+		{
+			name:        "one nanosecond before not before",
+			notBefore:   now,
+			cmp:         now.Add(-time.Nanosecond),
+			expectError: jwtErrors.ErrNbfBefore,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateNotBefore(tc.notBefore, tc.cmp)
+
+			if tc.expectError == nil {
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+			} else {
+				if !errors.Is(err, tc.expectError) {
+					t.Fatalf("expected error %v, got: %v", tc.expectError, err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateIssuedAt(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	testCases := []struct {
+		name        string
+		issuedAt    time.Time
+		cmp         time.Time
+		expectError error
+	}{
+		{
+			name:        "after issued at",
+			issuedAt:    now.Add(-time.Hour),
+			cmp:         now,
+			expectError: nil,
+		},
+		{
+			name:        "before issued at",
+			issuedAt:    now.Add(time.Hour),
+			cmp:         now,
+			expectError: jwtErrors.ErrIatBefore,
+		},
+		{
+			name:        "exactly at issued at",
+			issuedAt:    now,
+			cmp:         now,
+			expectError: nil,
+		},
+		{
+			name:        "one nanosecond before issued at",
+			issuedAt:    now,
+			cmp:         now.Add(-time.Nanosecond),
+			expectError: jwtErrors.ErrIatBefore,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateIssuedAt(tc.issuedAt, tc.cmp)
+
+			if tc.expectError == nil {
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+			} else {
+				if !errors.Is(err, tc.expectError) {
+					t.Fatalf("expected error %v, got: %v", tc.expectError, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/json/jose/jwt/types/authenticator/authenticator.go
+++ b/pkg/json/jose/jwt/types/authenticator/authenticator.go
@@ -68,7 +68,7 @@ func (a *AuthenticatorWithKeyHandler) Authenticate(ctx context.Context, tokenStr
 
 	token, err := motmedelJwkToken.New(tokenString)
 	if err != nil {
-		return nil, motmedelErrors.NewWithTrace(fmt.Errorf("%w: token new %w", motmedelErrors.ErrParseError, err))
+		return nil, motmedelErrors.NewWithTrace(fmt.Errorf("%w: token new: %w", motmedelErrors.ErrParseError, err))
 	}
 	if token == nil {
 		return nil, motmedelErrors.NewWithTrace(nil_error.New("jwt token"))

--- a/pkg/json/jose/jwt/types/claim_strings/claim_strings_test.go
+++ b/pkg/json/jose/jwt/types/claim_strings/claim_strings_test.go
@@ -1,0 +1,284 @@
+package claim_strings
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	motmedelErrors "github.com/Motmedel/utils_go/pkg/errors"
+)
+
+func TestClaimStrings_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		input       string
+		expected    ClaimStrings
+		expectError bool
+	}{
+		{
+			name:     "single string",
+			input:    `"audience1"`,
+			expected: ClaimStrings{"audience1"},
+		},
+		{
+			name:     "array of strings",
+			input:    `["audience1", "audience2", "audience3"]`,
+			expected: ClaimStrings{"audience1", "audience2", "audience3"},
+		},
+		{
+			name:     "empty array",
+			input:    `[]`,
+			expected: ClaimStrings{},
+		},
+		{
+			name:     "null value",
+			input:    `null`,
+			expected: nil,
+		},
+		{
+			name:        "invalid json",
+			input:       `{invalid`,
+			expectError: true,
+		},
+		{
+			name:        "array with non-string",
+			input:       `["valid", 123]`,
+			expectError: true,
+		},
+		{
+			name:        "number instead of string",
+			input:       `123`,
+			expectError: true,
+		},
+		{
+			name:        "object instead of string",
+			input:       `{"key": "value"}`,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var cs ClaimStrings
+			err := json.Unmarshal([]byte(tc.input), &cs)
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				if len(cs) != len(tc.expected) {
+					t.Fatalf("expected length %d, got %d", len(tc.expected), len(cs))
+				}
+
+				for i, v := range tc.expected {
+					if cs[i] != v {
+						t.Fatalf("expected %s at index %d, got %s", v, i, cs[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestClaimStrings_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	// Save and restore the global setting
+	originalSetting := MarshalSingleStringAsArray
+
+	testCases := []struct {
+		name                      string
+		input                     ClaimStrings
+		marshalSingleStringAsArr  bool
+		expected                  string
+	}{
+		{
+			name:                     "single string as array",
+			input:                    ClaimStrings{"audience1"},
+			marshalSingleStringAsArr: true,
+			expected:                 `["audience1"]`,
+		},
+		{
+			name:                     "single string as string",
+			input:                    ClaimStrings{"audience1"},
+			marshalSingleStringAsArr: false,
+			expected:                 `"audience1"`,
+		},
+		{
+			name:                     "multiple strings always as array",
+			input:                    ClaimStrings{"audience1", "audience2"},
+			marshalSingleStringAsArr: false,
+			expected:                 `["audience1","audience2"]`,
+		},
+		{
+			name:                     "empty array",
+			input:                    ClaimStrings{},
+			marshalSingleStringAsArr: true,
+			expected:                 `[]`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Note: Not using t.Parallel() here because we modify global state
+			MarshalSingleStringAsArray = tc.marshalSingleStringAsArr
+
+			b, err := json.Marshal(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if string(b) != tc.expected {
+				t.Fatalf("expected %s, got %s", tc.expected, string(b))
+			}
+		})
+	}
+
+	// Restore original setting
+	MarshalSingleStringAsArray = originalSetting
+}
+
+func TestConvert(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		input       any
+		expected    ClaimStrings
+		expectError bool
+		errorCheck  func(error) bool
+	}{
+		{
+			name:     "single string",
+			input:    "audience1",
+			expected: ClaimStrings{"audience1"},
+		},
+		{
+			name:     "string slice",
+			input:    []string{"audience1", "audience2"},
+			expected: ClaimStrings{"audience1", "audience2"},
+		},
+		{
+			name:     "any slice with strings",
+			input:    []any{"audience1", "audience2"},
+			expected: ClaimStrings{"audience1", "audience2"},
+		},
+		{
+			name:        "any slice with non-string",
+			input:       []any{"audience1", 123},
+			expectError: true,
+		},
+		{
+			name:        "integer (unsupported)",
+			input:       123,
+			expectError: true,
+			errorCheck: func(err error) bool {
+				return errors.Is(err, motmedelErrors.ErrUnexpectedType)
+			},
+		},
+		{
+			name:        "nil (unsupported)",
+			input:       nil,
+			expectError: true,
+			errorCheck: func(err error) bool {
+				return errors.Is(err, motmedelErrors.ErrUnexpectedType)
+			},
+		},
+		{
+			name:        "map (unsupported)",
+			input:       map[string]string{"key": "value"},
+			expectError: true,
+			errorCheck: func(err error) bool {
+				return errors.Is(err, motmedelErrors.ErrUnexpectedType)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := Convert(tc.input)
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				if tc.errorCheck != nil && !tc.errorCheck(err) {
+					t.Fatalf("error check failed for error: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				if len(result) != len(tc.expected) {
+					t.Fatalf("expected length %d, got %d", len(tc.expected), len(result))
+				}
+
+				for i, v := range tc.expected {
+					if result[i] != v {
+						t.Fatalf("expected %s at index %d, got %s", v, i, result[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestMarshalUnmarshalRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		input ClaimStrings
+	}{
+		{
+			name:  "single string",
+			input: ClaimStrings{"audience1"},
+		},
+		{
+			name:  "multiple strings",
+			input: ClaimStrings{"audience1", "audience2", "audience3"},
+		},
+		{
+			name:  "empty",
+			input: ClaimStrings{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b, err := json.Marshal(tc.input)
+			if err != nil {
+				t.Fatalf("marshal error: %v", err)
+			}
+
+			var decoded ClaimStrings
+			if err := json.Unmarshal(b, &decoded); err != nil {
+				t.Fatalf("unmarshal error: %v", err)
+			}
+
+			if len(decoded) != len(tc.input) {
+				t.Fatalf("round trip failed: expected length %d, got %d", len(tc.input), len(decoded))
+			}
+
+			for i, v := range tc.input {
+				if decoded[i] != v {
+					t.Fatalf("round trip failed at index %d: expected %s, got %s", i, v, decoded[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/json/jose/jwt/types/numeric_date/numeric_date_test.go
+++ b/pkg/json/jose/jwt/types/numeric_date/numeric_date_test.go
@@ -1,0 +1,289 @@
+package numeric_date
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	motmedelErrors "github.com/Motmedel/utils_go/pkg/errors"
+)
+
+func TestNewFromSeconds(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		seconds  float64
+		expected time.Time
+	}{
+		{
+			name:     "zero",
+			seconds:  0,
+			expected: time.Unix(0, 0),
+		},
+		{
+			name:     "positive integer",
+			seconds:  1609459200, // 2021-01-01 00:00:00 UTC
+			expected: time.Unix(1609459200, 0),
+		},
+		{
+			name:     "positive with fraction",
+			seconds:  1609459200.5,
+			expected: time.Unix(1609459200, 500000000),
+		},
+		{
+			name:     "negative integer",
+			seconds:  -86400, // 1969-12-31 00:00:00 UTC
+			expected: time.Unix(-86400, 0),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			date := NewFromSeconds(tc.seconds)
+
+			// Compare truncated times since TimePrecision is applied
+			expectedTruncated := tc.expected.Truncate(TimePrecision)
+			if !date.Time.Equal(expectedTruncated) {
+				t.Fatalf("expected %v, got %v", expectedTruncated, date.Time)
+			}
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	date := New(now)
+
+	expected := now.Truncate(TimePrecision)
+	if !date.Time.Equal(expected) {
+		t.Fatalf("expected %v, got %v", expected, date.Time)
+	}
+}
+
+func TestDate_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		date     Date
+		expected string
+	}{
+		{
+			name:     "zero time",
+			date:     Date{time.Unix(0, 0)},
+			expected: "0",
+		},
+		{
+			name:     "positive timestamp",
+			date:     Date{time.Unix(1609459200, 0)},
+			expected: "1609459200",
+		},
+		{
+			name:     "negative timestamp",
+			date:     Date{time.Unix(-86400, 0)},
+			expected: "-86400",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b, err := tc.date.MarshalJSON()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if string(b) != tc.expected {
+				t.Fatalf("expected %s, got %s", tc.expected, string(b))
+			}
+		})
+	}
+}
+
+func TestDate_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		input       string
+		expected    time.Time
+		expectError bool
+	}{
+		{
+			name:     "zero",
+			input:    "0",
+			expected: time.Unix(0, 0),
+		},
+		{
+			name:     "positive integer",
+			input:    "1609459200",
+			expected: time.Unix(1609459200, 0),
+		},
+		{
+			name:     "positive float",
+			input:    "1609459200.5",
+			expected: time.Unix(1609459200, 500000000),
+		},
+		{
+			name:     "negative integer",
+			input:    "-86400",
+			expected: time.Unix(-86400, 0),
+		},
+		{
+			name:        "invalid json",
+			input:       "invalid",
+			expectError: true,
+		},
+		{
+			name:        "string value",
+			input:       `"not a number"`,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var date Date
+			err := date.UnmarshalJSON([]byte(tc.input))
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				expectedTruncated := tc.expected.Truncate(TimePrecision)
+				if !date.Time.Equal(expectedTruncated) {
+					t.Fatalf("expected %v, got %v", expectedTruncated, date.Time)
+				}
+			}
+		})
+	}
+}
+
+func TestConvert(t *testing.T) {
+	t.Parallel()
+
+	testDate := New(time.Unix(1609459200, 0))
+
+	testCases := []struct {
+		name        string
+		input       any
+		expected    *Date
+		expectError bool
+		errorCheck  func(error) bool
+	}{
+		{
+			name:     "*Date input",
+			input:    testDate,
+			expected: testDate,
+		},
+		{
+			name:     "Date input",
+			input:    *testDate,
+			expected: testDate,
+		},
+		{
+			name:     "float64 input",
+			input:    float64(1609459200),
+			expected: New(time.Unix(1609459200, 0)),
+		},
+		{
+			name:     "float64 zero returns nil",
+			input:    float64(0),
+			expected: nil,
+		},
+		{
+			name:     "json.Number input",
+			input:    json.Number("1609459200"),
+			expected: New(time.Unix(1609459200, 0)),
+		},
+		{
+			name:        "json.Number invalid",
+			input:       json.Number("not-a-number"),
+			expectError: true,
+		},
+		{
+			name:        "unsupported type",
+			input:       "string",
+			expectError: true,
+			errorCheck: func(err error) bool {
+				return errors.Is(err, motmedelErrors.ErrUnexpectedType)
+			},
+		},
+		{
+			name:        "int type (unsupported)",
+			input:       1609459200,
+			expectError: true,
+			errorCheck: func(err error) bool {
+				return errors.Is(err, motmedelErrors.ErrUnexpectedType)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := Convert(tc.input)
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				if tc.errorCheck != nil && !tc.errorCheck(err) {
+					t.Fatalf("error check failed for error: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				if tc.expected == nil {
+					if result != nil {
+						t.Fatalf("expected nil, got %v", result)
+					}
+				} else {
+					if result == nil {
+						t.Fatal("expected non-nil result, got nil")
+					}
+					if !result.Time.Equal(tc.expected.Time) {
+						t.Fatalf("expected %v, got %v", tc.expected.Time, result.Time)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestMarshalUnmarshalRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := New(time.Unix(1609459200, 0))
+
+	b, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded Date
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if !original.Time.Equal(decoded.Time) {
+		t.Fatalf("round trip failed: original %v, decoded %v", original.Time, decoded.Time)
+	}
+}

--- a/pkg/json/jose/jwt/types/validator/session_claims_validator/session_claims_validator.go
+++ b/pkg/json/jose/jwt/types/validator/session_claims_validator/session_claims_validator.go
@@ -67,6 +67,7 @@ func (validator *Validator) Validate(parsedClaims map[string]any) error {
 					errs,
 					motmedelErrors.New(fmt.Errorf("convert (%s): %w", key, err), value),
 				)
+				continue
 			}
 
 			if authenticationMethodsComparer := expected.AuthenticationMethodsComparer; !utils.IsNil(authenticationMethodsComparer) {
@@ -130,6 +131,7 @@ func (validator *Validator) Validate(parsedClaims map[string]any) error {
 					errs,
 					motmedelErrors.New(fmt.Errorf("convert (%s): %w", key, err), value),
 				)
+				continue
 			}
 
 			if rolesComparer := expected.RolesComparer; !utils.IsNil(rolesComparer) {

--- a/pkg/json/jose/jwt/types/validator/session_claims_validator/session_claims_validator_test.go
+++ b/pkg/json/jose/jwt/types/validator/session_claims_validator/session_claims_validator_test.go
@@ -1,0 +1,293 @@
+package session_claims_validator
+
+import (
+	"errors"
+	"testing"
+
+	motmedelErrors "github.com/Motmedel/utils_go/pkg/errors"
+	"github.com/Motmedel/utils_go/pkg/interfaces/comparer"
+)
+
+// mockComparer is a test comparer that returns a predefined result
+type mockComparer[T any] struct {
+	result bool
+	err    error
+}
+
+func (m *mockComparer[T]) Compare(value T) (bool, error) {
+	return m.result, m.err
+}
+
+func TestValidator_Validate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		validator   *Validator
+		claims      map[string]any
+		expectError bool
+		errorCheck  func(error) bool
+	}{
+		{
+			name:        "nil claims returns error",
+			validator:   &Validator{},
+			claims:      nil,
+			expectError: true,
+			errorCheck: func(err error) bool {
+				return errors.Is(err, motmedelErrors.ErrValidationError)
+			},
+		},
+		{
+			name:        "empty claims passes with no validators",
+			validator:   &Validator{},
+			claims:      map[string]any{},
+			expectError: false,
+		},
+		{
+			name: "valid amr claim with matching comparer",
+			validator: &Validator{
+				Expected: &ExpectedClaims{
+					AuthenticationMethodsComparer: &mockComparer[string]{result: true},
+				},
+			},
+			claims: map[string]any{
+				"amr": []any{"pwd", "mfa"},
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid amr type triggers conversion error and continues (bug fix test)",
+			validator: &Validator{
+				Expected: &ExpectedClaims{
+					AuthenticationMethodsComparer: &mockComparer[string]{result: true},
+				},
+			},
+			claims: map[string]any{
+				"amr": 12345, // invalid type - should be []string or []any
+			},
+			expectError: true,
+			errorCheck: func(err error) bool {
+				// Should get a validation error containing the conversion error
+				// but NOT a mismatch error (the bug was that it would also add mismatch)
+				return errors.Is(err, motmedelErrors.ErrValidationError)
+			},
+		},
+		{
+			name: "amr claim with no match returns mismatch error",
+			validator: &Validator{
+				Expected: &ExpectedClaims{
+					AuthenticationMethodsComparer: &mockComparer[string]{result: false},
+				},
+			},
+			claims: map[string]any{
+				"amr": []any{"pwd"},
+			},
+			expectError: true,
+			errorCheck: func(err error) bool {
+				return errors.Is(err, motmedelErrors.ErrValidationError)
+			},
+		},
+		{
+			name: "valid roles claim with matching comparer",
+			validator: &Validator{
+				Expected: &ExpectedClaims{
+					RolesComparer: &mockComparer[string]{result: true},
+				},
+			},
+			claims: map[string]any{
+				"roles": []any{"admin", "user"},
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid roles type triggers conversion error and continues (bug fix test)",
+			validator: &Validator{
+				Expected: &ExpectedClaims{
+					RolesComparer: &mockComparer[string]{result: true},
+				},
+			},
+			claims: map[string]any{
+				"roles": 12345, // invalid type - should be []string or []any
+			},
+			expectError: true,
+			errorCheck: func(err error) bool {
+				// Should get a validation error containing the conversion error
+				// but NOT a mismatch error (the bug was that it would also add mismatch)
+				return errors.Is(err, motmedelErrors.ErrValidationError)
+			},
+		},
+		{
+			name: "roles claim with no match returns mismatch error",
+			validator: &Validator{
+				Expected: &ExpectedClaims{
+					RolesComparer: &mockComparer[string]{result: false},
+				},
+			},
+			claims: map[string]any{
+				"roles": []any{"user"},
+			},
+			expectError: true,
+			errorCheck: func(err error) bool {
+				return errors.Is(err, motmedelErrors.ErrValidationError)
+			},
+		},
+		{
+			name: "valid azp claim with matching comparer",
+			validator: &Validator{
+				Expected: &ExpectedClaims{
+					AuthorizedPartyComparer: &mockComparer[string]{result: true},
+				},
+			},
+			claims: map[string]any{
+				"azp": "my-client-id",
+			},
+			expectError: false,
+		},
+		{
+			name: "azp claim with no match returns mismatch error",
+			validator: &Validator{
+				Expected: &ExpectedClaims{
+					AuthorizedPartyComparer: &mockComparer[string]{result: false},
+				},
+			},
+			claims: map[string]any{
+				"azp": "wrong-client-id",
+			},
+			expectError: true,
+			errorCheck: func(err error) bool {
+				return errors.Is(err, motmedelErrors.ErrValidationError)
+			},
+		},
+		{
+			name: "other comparer validates custom claim",
+			validator: &Validator{
+				Expected: &ExpectedClaims{
+					OtherComparers: map[string]comparer.Comparer[any]{
+						"custom_claim": &mockComparer[any]{result: true},
+					},
+				},
+			},
+			claims: map[string]any{
+				"custom_claim": "some_value",
+			},
+			expectError: false,
+		},
+		{
+			name: "other comparer rejects non-matching custom claim",
+			validator: &Validator{
+				Expected: &ExpectedClaims{
+					OtherComparers: map[string]comparer.Comparer[any]{
+						"custom_claim": &mockComparer[any]{result: false},
+					},
+				},
+			},
+			claims: map[string]any{
+				"custom_claim": "wrong_value",
+			},
+			expectError: true,
+			errorCheck: func(err error) bool {
+				return errors.Is(err, motmedelErrors.ErrValidationError)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.validator.Validate(tc.claims)
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				if tc.errorCheck != nil && !tc.errorCheck(err) {
+					t.Fatalf("error check failed for error: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestAmrConversionErrorContinues specifically tests the bug fix where
+// a conversion error for 'amr' should NOT also trigger a mismatch error
+func TestAmrConversionErrorContinues(t *testing.T) {
+	t.Parallel()
+
+	// This comparer should never be called if conversion fails
+	callCount := 0
+	countingComparer := &countingMockComparer[string]{
+		callCount: &callCount,
+		result:    false, // Would cause mismatch if called
+	}
+
+	validator := &Validator{
+		Expected: &ExpectedClaims{
+			AuthenticationMethodsComparer: countingComparer,
+		},
+	}
+
+	claims := map[string]any{
+		"amr": "not-an-array", // Invalid type
+	}
+
+	err := validator.Validate(claims)
+	if err == nil {
+		t.Fatal("expected error for invalid amr type")
+	}
+
+	// The comparer should NOT have been called because conversion failed
+	// and we should have continued to the next claim
+	if callCount > 0 {
+		t.Fatalf("comparer should not have been called after conversion error, but was called %d times", callCount)
+	}
+}
+
+// TestRolesConversionErrorContinues specifically tests the bug fix where
+// a conversion error for 'roles' should NOT also trigger a mismatch error
+func TestRolesConversionErrorContinues(t *testing.T) {
+	t.Parallel()
+
+	// This comparer should never be called if conversion fails
+	callCount := 0
+	countingComparer := &countingMockComparer[string]{
+		callCount: &callCount,
+		result:    false, // Would cause mismatch if called
+	}
+
+	validator := &Validator{
+		Expected: &ExpectedClaims{
+			RolesComparer: countingComparer,
+		},
+	}
+
+	claims := map[string]any{
+		"roles": "not-an-array", // Invalid type
+	}
+
+	err := validator.Validate(claims)
+	if err == nil {
+		t.Fatal("expected error for invalid roles type")
+	}
+
+	// The comparer should NOT have been called because conversion failed
+	// and we should have continued to the next claim
+	if callCount > 0 {
+		t.Fatalf("comparer should not have been called after conversion error, but was called %d times", callCount)
+	}
+}
+
+type countingMockComparer[T any] struct {
+	callCount *int
+	result    bool
+	err       error
+}
+
+func (m *countingMockComparer[T]) Compare(value T) (bool, error) {
+	*m.callCount++
+	return m.result, m.err
+}


### PR DESCRIPTION
## Summary
This PR adds extensive unit test coverage for the JWT and JWK packages, including tests for EC and RSA key types, JWT parsing and validation, claim handling, and session claims validation. Additionally, two bug fixes are included in the validator logic.

## Key Changes

### New Test Files
- **`pkg/json/jose/jwk/types/key/ec/ec_test.go`**: Comprehensive tests for EC key operations
  - `TestCurveFromCrv`: Tests curve resolution from JWK curve parameter
  - `TestKey_PublicKey`: Tests EC public key extraction with various curves (P-256, P-384, P-521)
  - `TestNew`: Tests EC key creation from map with validation of required fields and types

- **`pkg/json/jose/jwk/types/key/rsa/rsa_test.go`**: Comprehensive tests for RSA key operations
  - `TestKey_PublicKey`: Tests RSA public key extraction from modulus and exponent
  - `TestNew`: Tests RSA key creation from map with validation of required fields and types

- **`pkg/json/jose/jwt/jwt_test.go`**: Core JWT functionality tests
  - `TestSplitToken`: Tests JWT token splitting into header, payload, and signature
  - `TestParse`: Tests JWT parsing with base64 decoding
  - `TestValidateExpiresAt`: Tests expiration time validation
  - `TestValidateNotBefore`: Tests not-before time validation
  - `TestValidateIssuedAt`: Tests issued-at time validation

- **`pkg/json/jose/jwt/types/claim_strings/claim_strings_test.go`**: Tests for string claim handling
  - `TestClaimStrings_UnmarshalJSON`: Tests unmarshaling single strings and arrays
  - `TestClaimStrings_MarshalJSON`: Tests marshaling with configurable array format
  - `TestConvert`: Tests type conversion for claim strings
  - `TestMarshalUnmarshalRoundTrip`: Tests serialization round-trip

- **`pkg/json/jose/jwt/types/numeric_date/numeric_date_test.go`**: Tests for numeric date handling
  - `TestNewFromSeconds`: Tests date creation from Unix timestamps
  - `TestDate_MarshalJSON`: Tests JSON serialization of dates
  - `TestDate_UnmarshalJSON`: Tests JSON deserialization of dates
  - `TestConvert`: Tests type conversion for numeric dates
  - `TestMarshalUnmarshalRoundTrip`: Tests serialization round-trip

- **`pkg/json/jose/jwt/types/validator/session_claims_validator/session_claims_validator_test.go`**: Tests for session claims validation
  - `TestValidator_Validate`: Comprehensive validation tests for various claim types
  - `TestAmrConversionErrorContinues`: Tests bug fix for authentication methods conversion errors
  - `TestRolesConversionErrorContinues`: Tests bug fix for roles conversion errors

### Bug Fixes
- **`pkg/json/jose/jwt/types/validator/session_claims_validator/session_claims_validator.go`**: Added missing `continue` statements after conversion errors for `amr` and `roles` claims
  - Prevents duplicate error reporting when claim conversion fails
  - Ensures the validator continues to the next claim after a conversion error instead of attempting comparison

### Minor Improvements
- **`pkg/json/jose/jwt/types/authenticator/authenticator.go`**: Improved error message formatting (changed `%w` to `: %w` for better readability)

## Test Coverage
All tests follow Go testing best practices:
- Parallel execution where appropriate
- Comprehensive error case coverage
- Type validation and edge case testing
- Round-trip serialization/deserialization verification
- Mock comparers for isolated unit testing

https://claude.ai/code/session_01FWSuBTGA33bCJ7xDM5LrkU