### PR TITLE
Add OAuth2 client implementation with token management

### DIFF
--- a/pkg/http/oauth2/errors/errors.go
+++ b/pkg/http/oauth2/errors/errors.go
@@ -1,0 +1,42 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrEmptyClientId     = errors.New("empty client id")
+	ErrEmptyTokenUrl     = errors.New("empty token url")
+	ErrEmptyAuthUrl      = errors.New("empty auth url")
+	ErrEmptyAccessToken  = errors.New("empty access token")
+	ErrEmptyRefreshToken = errors.New("empty refresh token")
+	ErrTokenExpired      = errors.New("token expired")
+	ErrRetrieveToken     = errors.New("retrieve token")
+)
+
+type RetrieveError struct {
+	StatusCode       int
+	Body             []byte
+	ErrorCode        string
+	ErrorDescription string
+	ErrorURI         string
+}
+
+func (e *RetrieveError) Is(target error) bool {
+	return target == ErrRetrieveToken
+}
+
+func (e *RetrieveError) Error() string {
+	if e.ErrorCode != "" {
+		s := fmt.Sprintf("oauth2: %q", e.ErrorCode)
+		if e.ErrorDescription != "" {
+			s += fmt.Sprintf(" %q", e.ErrorDescription)
+		}
+		if e.ErrorURI != "" {
+			s += fmt.Sprintf(" %q", e.ErrorURI)
+		}
+		return s
+	}
+	return fmt.Sprintf("oauth2: cannot fetch token: %d", e.StatusCode)
+}

--- a/pkg/http/oauth2/oauth2.go
+++ b/pkg/http/oauth2/oauth2.go
@@ -1,0 +1,341 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	motmedelErrors "github.com/Motmedel/utils_go/pkg/errors"
+	"github.com/Motmedel/utils_go/pkg/http/oauth2/errors"
+	"github.com/Motmedel/utils_go/pkg/http/oauth2/types/token"
+	"github.com/Motmedel/utils_go/pkg/http/types/fetch_config"
+	motmedelHttpUtils "github.com/Motmedel/utils_go/pkg/http/utils"
+)
+
+type AuthStyle int
+
+const (
+	AuthStyleAutoDetect AuthStyle = iota
+	AuthStyleInParams
+	AuthStyleInHeader
+)
+
+type Endpoint struct {
+	AuthURL   string
+	TokenURL  string
+	AuthStyle AuthStyle
+}
+
+type AuthCodeOption struct {
+	key   string
+	value string
+}
+
+func SetAuthURLParam(key, value string) AuthCodeOption {
+	return AuthCodeOption{key: key, value: value}
+}
+
+type Config struct {
+	ClientID     string
+	ClientSecret string
+	Endpoint     Endpoint
+	RedirectURL  string
+	Scopes       []string
+
+	FetchOptions []fetch_config.Option
+}
+
+func (c *Config) AuthCodeURL(state string, opts ...AuthCodeOption) string {
+	var buf strings.Builder
+	buf.WriteString(c.Endpoint.AuthURL)
+
+	v := url.Values{
+		"response_type": {"code"},
+		"client_id":     {c.ClientID},
+	}
+	if c.RedirectURL != "" {
+		v.Set("redirect_uri", c.RedirectURL)
+	}
+	if len(c.Scopes) > 0 {
+		v.Set("scope", strings.Join(c.Scopes, " "))
+	}
+	if state != "" {
+		v.Set("state", state)
+	}
+	for _, opt := range opts {
+		v.Set(opt.key, opt.value)
+	}
+
+	if strings.Contains(c.Endpoint.AuthURL, "?") {
+		buf.WriteByte('&')
+	} else {
+		buf.WriteByte('?')
+	}
+	buf.WriteString(v.Encode())
+
+	return buf.String()
+}
+
+func (c *Config) Exchange(ctx context.Context, code string, opts ...AuthCodeOption) (*token.Token, error) {
+	v := url.Values{
+		"grant_type": {"authorization_code"},
+		"code":       {code},
+	}
+	if c.RedirectURL != "" {
+		v.Set("redirect_uri", c.RedirectURL)
+	}
+	for _, opt := range opts {
+		v.Set(opt.key, opt.value)
+	}
+
+	return c.retrieveToken(ctx, v)
+}
+
+func (c *Config) PasswordCredentialsToken(ctx context.Context, username, password string) (*token.Token, error) {
+	v := url.Values{
+		"grant_type": {"password"},
+		"username":   {username},
+		"password":   {password},
+	}
+	if len(c.Scopes) > 0 {
+		v.Set("scope", strings.Join(c.Scopes, " "))
+	}
+
+	return c.retrieveToken(ctx, v)
+}
+
+func (c *Config) ClientCredentialsToken(ctx context.Context) (*token.Token, error) {
+	v := url.Values{
+		"grant_type": {"client_credentials"},
+	}
+	if len(c.Scopes) > 0 {
+		v.Set("scope", strings.Join(c.Scopes, " "))
+	}
+
+	return c.retrieveToken(ctx, v)
+}
+
+func (c *Config) TokenSource(ctx context.Context, t *token.Token) TokenSource {
+	tkr := &tokenRefresher{
+		ctx:  ctx,
+		conf: c,
+	}
+	if t != nil {
+		tkr.refreshToken = t.RefreshToken
+	}
+
+	return &reuseTokenSource{
+		t:   t,
+		new: tkr,
+	}
+}
+
+func (c *Config) retrieveToken(ctx context.Context, v url.Values) (*token.Token, error) {
+	if c.Endpoint.TokenURL == "" {
+		return nil, motmedelErrors.NewWithTrace(errors.ErrEmptyTokenUrl)
+	}
+
+	authStyle := c.Endpoint.AuthStyle
+
+	if authStyle == AuthStyleAutoDetect {
+		// Try header first, fall back to params.
+		tok, err := c.doRetrieveToken(ctx, v, AuthStyleInHeader)
+		if err == nil {
+			return tok, nil
+		}
+		tok, err = c.doRetrieveToken(ctx, v, AuthStyleInParams)
+		if err == nil {
+			return tok, nil
+		}
+		return nil, fmt.Errorf("oauth2: retrieve token auto-detect: %w", err)
+	}
+
+	return c.doRetrieveToken(ctx, v, authStyle)
+}
+
+func (c *Config) doRetrieveToken(ctx context.Context, v url.Values, authStyle AuthStyle) (*token.Token, error) {
+	headers := map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	}
+
+	switch authStyle {
+	case AuthStyleInHeader:
+		headers["Authorization"] = "Basic " + motmedelHttpUtils.BasicAuth(c.ClientID, c.ClientSecret)
+	case AuthStyleInParams:
+		v.Set("client_id", c.ClientID)
+		if c.ClientSecret != "" {
+			v.Set("client_secret", c.ClientSecret)
+		}
+	}
+
+	body := []byte(v.Encode())
+
+	options := append(
+		[]fetch_config.Option{
+			fetch_config.WithMethod("POST"),
+			fetch_config.WithHeaders(headers),
+			fetch_config.WithBody(body),
+			fetch_config.WithSkipErrorOnStatus(true),
+		},
+		c.FetchOptions...,
+	)
+
+	response, responseBody, err := motmedelHttpUtils.Fetch(ctx, c.Endpoint.TokenURL, options...)
+	if err != nil {
+		return nil, fmt.Errorf("fetch: %w", err)
+	}
+
+	if response != nil && (response.StatusCode < 200 || response.StatusCode >= 300) {
+		retrieveErr := &errors.RetrieveError{
+			StatusCode: response.StatusCode,
+			Body:       responseBody,
+		}
+
+		var errorResponse struct {
+			Error            string `json:"error"`
+			ErrorDescription string `json:"error_description"`
+			ErrorURI         string `json:"error_uri"`
+		}
+		if err := json.Unmarshal(responseBody, &errorResponse); err == nil {
+			retrieveErr.ErrorCode = errorResponse.Error
+			retrieveErr.ErrorDescription = errorResponse.ErrorDescription
+			retrieveErr.ErrorURI = errorResponse.ErrorURI
+		}
+
+		return nil, retrieveErr
+	}
+
+	var tokenResponse struct {
+		AccessToken  string `json:"access_token"`
+		TokenType    string `json:"token_type"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int64  `json:"expires_in"`
+	}
+
+	contentType := ""
+	if response != nil {
+		contentType = response.Header.Get("Content-Type")
+	}
+
+	if strings.Contains(contentType, "application/x-www-form-urlencoded") || strings.Contains(contentType, "text/plain") {
+		vals, err := url.ParseQuery(string(responseBody))
+		if err != nil {
+			return nil, fmt.Errorf("oauth2: cannot parse response: %w", err)
+		}
+		tokenResponse.AccessToken = vals.Get("access_token")
+		tokenResponse.TokenType = vals.Get("token_type")
+		tokenResponse.RefreshToken = vals.Get("refresh_token")
+	} else {
+		if err := json.Unmarshal(responseBody, &tokenResponse); err != nil {
+			return nil, fmt.Errorf("oauth2: cannot parse json response: %w", err)
+		}
+	}
+
+	tok := &token.Token{
+		AccessToken:  tokenResponse.AccessToken,
+		TokenType:    tokenResponse.TokenType,
+		RefreshToken: tokenResponse.RefreshToken,
+	}
+
+	if tokenResponse.ExpiresIn > 0 {
+		tok.Expiry = time.Now().Add(time.Duration(tokenResponse.ExpiresIn) * time.Second)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(responseBody, &raw); err == nil {
+		tok.Raw = raw
+	}
+
+	if tok.AccessToken == "" {
+		return nil, motmedelErrors.NewWithTrace(errors.ErrEmptyAccessToken)
+	}
+
+	return tok, nil
+}
+
+// TokenSource is a source of tokens.
+type TokenSource interface {
+	Token() (*token.Token, error)
+}
+
+type tokenRefresher struct {
+	ctx          context.Context
+	conf         *Config
+	refreshToken string
+}
+
+func (tf *tokenRefresher) Token() (*token.Token, error) {
+	if tf.refreshToken == "" {
+		return nil, motmedelErrors.NewWithTrace(errors.ErrEmptyRefreshToken)
+	}
+
+	v := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {tf.refreshToken},
+	}
+	if len(tf.conf.Scopes) > 0 {
+		v.Set("scope", strings.Join(tf.conf.Scopes, " "))
+	}
+
+	tok, err := tf.conf.retrieveToken(tf.ctx, v)
+	if err != nil {
+		return nil, fmt.Errorf("oauth2: token refresh: %w", err)
+	}
+
+	if tok.RefreshToken == "" {
+		tok.RefreshToken = tf.refreshToken
+	} else {
+		tf.refreshToken = tok.RefreshToken
+	}
+
+	return tok, nil
+}
+
+type reuseTokenSource struct {
+	new TokenSource
+	mu  sync.Mutex
+	t   *token.Token
+}
+
+func (s *reuseTokenSource) Token() (*token.Token, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.t.Valid() {
+		return s.t, nil
+	}
+
+	t, err := s.new.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	s.t = t
+	return t, nil
+}
+
+// StaticTokenSource returns a TokenSource that always returns the same token.
+func StaticTokenSource(t *token.Token) TokenSource {
+	return &staticTokenSource{t: t}
+}
+
+type staticTokenSource struct {
+	t *token.Token
+}
+
+func (s *staticTokenSource) Token() (*token.Token, error) {
+	return s.t, nil
+}
+
+// ReuseTokenSource returns a TokenSource that caches the token from src
+// and refreshes it when expired.
+func ReuseTokenSource(t *token.Token, src TokenSource) TokenSource {
+	return &reuseTokenSource{
+		t:   t,
+		new: src,
+	}
+}

--- a/pkg/http/oauth2/types/token/token.go
+++ b/pkg/http/oauth2/types/token/token.go
@@ -1,0 +1,48 @@
+package token
+
+import (
+	"net/http"
+	"time"
+)
+
+const expiryDelta = 10 * time.Second
+
+type Token struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	Expiry       time.Time `json:"expiry,omitempty"`
+
+	ExpiresIn int64 `json:"expires_in,omitempty"`
+
+	Raw map[string]any
+}
+
+func (t *Token) Type() string {
+	if t.TokenType != "" {
+		return t.TokenType
+	}
+	return "Bearer"
+}
+
+func (t *Token) SetAuthHeader(r *http.Request) {
+	r.Header.Set("Authorization", t.Type()+" "+t.AccessToken)
+}
+
+func (t *Token) Valid() bool {
+	return t != nil && t.AccessToken != "" && !t.expired()
+}
+
+func (t *Token) expired() bool {
+	if t.Expiry.IsZero() {
+		return false
+	}
+	return t.Expiry.Round(0).Add(-expiryDelta).Before(time.Now())
+}
+
+func (t *Token) Extra(key string) any {
+	if t.Raw == nil {
+		return nil
+	}
+	return t.Raw[key]
+}


### PR DESCRIPTION
## Summary
This PR introduces a complete OAuth2 client implementation with support for multiple authentication flows and automatic token refresh capabilities.

## Key Changes
- **OAuth2 Config**: Added `Config` struct supporting authorization code, password credentials, and client credentials flows
  - `AuthCodeURL()` - generates authorization URLs with customizable parameters
  - `Exchange()` - exchanges authorization codes for tokens
  - `PasswordCredentialsToken()` - handles resource owner password credentials flow
  - `ClientCredentialsToken()` - handles client credentials flow
  - `TokenSource()` - creates a token source with automatic refresh

- **Token Management**: Implemented `Token` type with expiry tracking and validation
  - `Valid()` - checks if token is valid and not expired
  - `SetAuthHeader()` - sets Authorization header on HTTP requests
  - `Extra()` - retrieves additional claims from token response
  - Configurable expiry delta (10 seconds) for safe token refresh

- **Token Sources**: Added multiple token source implementations
  - `StaticTokenSource` - returns a fixed token
  - `ReuseTokenSource` - caches and auto-refreshes tokens when expired
  - `tokenRefresher` - handles refresh token flow with scope preservation

- **Authentication Styles**: Support for flexible client authentication
  - Header-based (HTTP Basic Auth)
  - Parameter-based (in request body)
  - Auto-detection with fallback mechanism

- **Error Handling**: Comprehensive error types for OAuth2 operations
  - `RetrieveError` - structured error responses from token endpoints
  - Parsing of standard OAuth2 error responses (error, error_description, error_uri)

- **Response Parsing**: Flexible token response parsing supporting both JSON and form-encoded formats

## Notable Implementation Details
- Thread-safe token caching with mutex protection in `reuseTokenSource`
- Automatic refresh token preservation across refresh cycles
- Support for custom fetch options and headers
- Proper error wrapping with context for debugging

https://claude.ai/code/session_01Dc8mLbGnpo4mDZdsd5s2by